### PR TITLE
Fix greenhouse-todo initialization ReferenceError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env.*
 *.pem
 *.key
+node_modules/

--- a/greenhouse-todo/app.js
+++ b/greenhouse-todo/app.js
@@ -22,9 +22,6 @@ const instructions = document.getElementById('instructions');
 const uiContainer = document.getElementById('ui-container');
 const resumeBtn = document.getElementById('resume-btn');
 
-init();
-animate();
-
 function init() {
     // 1. Scene setup
     scene = new THREE.Scene();
@@ -534,6 +531,9 @@ document.getElementById('btn-acknowledge').addEventListener('click', function() 
         closeTodoModal();
     }
 });
+
+init();
+animate();
 
 document.getElementById('btn-complete').addEventListener('click', function() {
     if (activeTodo) {


### PR DESCRIPTION
Fixes the issue in `greenhouse-todo` where the screen was black. Moving the `init` and `animate` calls ensures all needed variables are initialized before use.

---
*PR created automatically by Jules for task [17369575975277231771](https://jules.google.com/task/17369575975277231771) started by @ealdent*