### PR TITLE
Fix mouse position hack and implement build preview in tower-def/gem31pro-tower-def.html

### DIFF
--- a/tower-def/gem31pro-tower-def.html
+++ b/tower-def/gem31pro-tower-def.html
@@ -234,8 +234,7 @@
 
     let selectedBuild = null;
     let selectedTower = null;
-    let mouseX = 0;
-    let mouseY = 0;
+    let mouse = { x: -1000, y: -1000 };
 
     // --- INITIALIZATION ---
     function init() {
@@ -328,19 +327,21 @@
         // Track mouse movement
         canvas.addEventListener('mousemove', (e) => {
             const pos = getMousePos(e);
-            mouseX = pos.x;
-            mouseY = pos.y;
+            mouse.x = pos.x;
+            mouse.y = pos.y;
+        });
+
+        canvas.addEventListener('mouseleave', () => {
+            mouse.x = -1000;
+            mouse.y = -1000;
         });
 
         // Canvas clicking for placement and selection
         canvas.addEventListener('mousedown', (e) => {
             if(gameState === 'gameover') return;
             const pos = getMousePos(e);
-            const x = pos.x;
-            const y = pos.y;
-
-            const gridX = Math.floor(x / TILE_SIZE);
-            const gridY = Math.floor(y / TILE_SIZE);
+            const gridX = Math.floor(pos.x / TILE_SIZE);
+            const gridY = Math.floor(pos.y / TILE_SIZE);
 
             if(gridX < 0 || gridX >= COLS || gridY < 0 || gridY >= ROWS) return;
 
@@ -707,15 +708,16 @@
         }
 
         // Draw Build Hover / Range
-        if(selectedBuild) {
-            const gridX = Math.floor(mouseX / TILE_SIZE);
-            const gridY = Math.floor(mouseY / TILE_SIZE);
+        if(selectedBuild && mouse.x >= 0) {
+            const gridX = Math.floor(mouse.x / TILE_SIZE);
+            const gridY = Math.floor(mouse.y / TILE_SIZE);
 
             if(gridX >= 0 && gridX < COLS && gridY >= 0 && gridY < ROWS) {
                 const bx = gridX * TILE_SIZE + TILE_SIZE / 2;
                 const by = gridY * TILE_SIZE + TILE_SIZE / 2;
                 const tType = TOWER_TYPES[selectedBuild];
 
+                ctx.save();
                 // Range preview
                 ctx.beginPath();
                 ctx.arc(bx, by, tType.range, 0, Math.PI * 2);
@@ -726,11 +728,13 @@
                 ctx.fillStyle = canPlace ? "rgba(255, 255, 255, 0.1)" : "rgba(255, 0, 0, 0.1)";
                 ctx.fill();
 
-                // Tower icon preview
+                // Ghost tower
                 ctx.globalAlpha = 0.5;
+                ctx.fillStyle = 'rgba(0,0,0,0.1)';
+                ctx.beginPath(); ctx.arc(bx, by + 10, 15, 0, Math.PI*2); ctx.fill();
                 ctx.font = "30px Arial";
                 ctx.fillText(tType.icon, bx, by);
-                ctx.globalAlpha = 1.0;
+                ctx.restore();
             }
         }
     }

--- a/tower-def/gem31pro-tower-def.html
+++ b/tower-def/gem31pro-tower-def.html
@@ -234,6 +234,8 @@
 
     let selectedBuild = null;
     let selectedTower = null;
+    let mouseX = 0;
+    let mouseY = 0;
 
     // --- INITIALIZATION ---
     function init() {
@@ -301,6 +303,16 @@
     }
 
     // --- UI SETUP & LOGIC ---
+    function getMousePos(e) {
+        const rect = canvas.getBoundingClientRect();
+        const scaleX = canvas.width / rect.width;
+        const scaleY = canvas.height / rect.height;
+        return {
+            x: (e.clientX - rect.left) * scaleX,
+            y: (e.clientY - rect.top) * scaleY
+        };
+    }
+
     function setupUI() {
         const buildMenu = document.getElementById('build-menu');
         for (const [key, t] of Object.entries(TOWER_TYPES)) {
@@ -313,14 +325,19 @@
 
         document.getElementById('wave-btn').onclick = startWave;
 
+        // Track mouse movement
+        canvas.addEventListener('mousemove', (e) => {
+            const pos = getMousePos(e);
+            mouseX = pos.x;
+            mouseY = pos.y;
+        });
+
         // Canvas clicking for placement and selection
         canvas.addEventListener('mousedown', (e) => {
             if(gameState === 'gameover') return;
-            const rect = canvas.getBoundingClientRect();
-            const scaleX = canvas.width / rect.width;
-            const scaleY = canvas.height / rect.height;
-            const x = (e.clientX - rect.left) * scaleX;
-            const y = (e.clientY - rect.top) * scaleY;
+            const pos = getMousePos(e);
+            const x = pos.x;
+            const y = pos.y;
 
             const gridX = Math.floor(x / TILE_SIZE);
             const gridY = Math.floor(y / TILE_SIZE);
@@ -691,8 +708,30 @@
 
         // Draw Build Hover / Range
         if(selectedBuild) {
-            // Get mouse position (rough hack using last known or center)
-            // Range preview is handled via CSS or keeping track of mouse, skipped for compactness
+            const gridX = Math.floor(mouseX / TILE_SIZE);
+            const gridY = Math.floor(mouseY / TILE_SIZE);
+
+            if(gridX >= 0 && gridX < COLS && gridY >= 0 && gridY < ROWS) {
+                const bx = gridX * TILE_SIZE + TILE_SIZE / 2;
+                const by = gridY * TILE_SIZE + TILE_SIZE / 2;
+                const tType = TOWER_TYPES[selectedBuild];
+
+                // Range preview
+                ctx.beginPath();
+                ctx.arc(bx, by, tType.range, 0, Math.PI * 2);
+                const canPlace = grid[gridX][gridY] === 0 && money >= tType.baseCost;
+                ctx.strokeStyle = canPlace ? "rgba(255, 255, 255, 0.5)" : "rgba(255, 0, 0, 0.5)";
+                ctx.lineWidth = 2;
+                ctx.stroke();
+                ctx.fillStyle = canPlace ? "rgba(255, 255, 255, 0.1)" : "rgba(255, 0, 0, 0.1)";
+                ctx.fill();
+
+                // Tower icon preview
+                ctx.globalAlpha = 0.5;
+                ctx.font = "30px Arial";
+                ctx.fillText(tType.icon, bx, by);
+                ctx.globalAlpha = 1.0;
+            }
         }
     }
 


### PR DESCRIPTION
Improved the mouse position calculation in `tower-def/gem31pro-tower-def.html` by replacing a 'rough hack' with proper mouse tracking. This change includes a new helper function to handle canvas scaling and a `mousemove` listener. Additionally, I implemented a visual preview for tower placement, showing the tower's range and a ghost icon at the snapped grid position, with color feedback based on placement validity.

---
*PR created automatically by Jules for task [11890391900214053192](https://jules.google.com/task/11890391900214053192) started by @ealdent*