### PR TITLE
🧹 Remove unused console.log in greenhouse-todo

### DIFF
--- a/utils/greenhouse-todo/app.js
+++ b/utils/greenhouse-todo/app.js
@@ -2668,7 +2668,6 @@ function updatePlantVisual(todo) {
 window.greenhouseDev = {
     fastForwardDays(n = 1) {
         simulatedTimeOffset += n * 86400000;
-        console.log(`Fast forwarded ${n} day(s). Offset is now ${simulatedTimeOffset / 86400000} days.`);
     },
     clearSave() {
         localStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
🎯 **What:** Removed an unused debugging `console.log` from the `window.greenhouseDev.fastForwardDays` method in `utils/greenhouse-todo/app.js`.
💡 **Why:** This improves code health and maintainability by cleaning up unused debugging print statements from the codebase.
✅ **Verification:** I manually verified the source file modification. I noted that this project does not contain a `package.json` with testing/lint scripts. I ran code review which passed the check successfully as it is a safe cleanup of unused logic.
✨ **Result:** A cleaner codebase with debugging statements removed without changing any game behavior.

---
*PR created automatically by Jules for task [5426984656750538232](https://jules.google.com/task/5426984656750538232) started by @ealdent*