### PR TITLE
🧪 Add tests for build_distribution function in slots-mc.py

### DIFF
--- a/scripts/test_slots_mc.py
+++ b/scripts/test_slots_mc.py
@@ -1,0 +1,61 @@
+import pytest
+import importlib.util
+import sys
+import math
+
+# Load the target module dynamically due to hyphen in filename
+spec = importlib.util.spec_from_file_location("slots_mc", "scripts/slots-mc.py")
+slots_mc = importlib.util.module_from_spec(spec)
+sys.modules["slots_mc"] = slots_mc
+spec.loader.exec_module(slots_mc)
+
+def test_build_distribution_empty():
+    with pytest.raises(ValueError, match="Please paste your previously determined probabilities into OUTCOMES."):
+        slots_mc.build_distribution([])
+
+def test_build_distribution_sum_too_high():
+    outcomes = [
+        ("outcome1", 0.6, 1.0),
+        ("outcome2", 0.5, 2.0),
+    ]
+    with pytest.raises(ValueError, match=r"Outcome probabilities sum to 1\.100000 \(>1\)\. Fix your inputs\."):
+        slots_mc.build_distribution(outcomes)
+
+def test_build_distribution_exact_sum():
+    outcomes = [
+        ("outcome1", 0.5, 1.0),
+        ("outcome2", 0.5, 2.0),
+    ]
+    dist = slots_mc.build_distribution(outcomes)
+
+    assert len(dist) == 2
+    assert dist[0].name == "outcome1"
+    assert math.isclose(dist[0].prob, 0.5)
+    assert dist[0].mult == 1.0
+
+    assert dist[1].name == "outcome2"
+    assert math.isclose(dist[1].prob, 0.5)
+    assert dist[1].mult == 2.0
+
+    assert math.isclose(sum(d.prob for d in dist), 1.0)
+
+def test_build_distribution_with_residual():
+    outcomes = [
+        ("outcome1", 0.4, 1.0),
+        ("outcome2", 0.3, 2.0),
+    ]
+    dist = slots_mc.build_distribution(outcomes)
+
+    assert len(dist) == 3
+    assert dist[0].name == "outcome1"
+    assert math.isclose(dist[0].prob, 0.4)
+
+    assert dist[1].name == "outcome2"
+    assert math.isclose(dist[1].prob, 0.3)
+
+    # Residual loss
+    assert dist[2].name == "loss (residual)"
+    assert math.isclose(dist[2].prob, 0.3)  # 1.0 - 0.7
+    assert dist[2].mult == 0.0
+
+    assert math.isclose(sum(d.prob for d in dist), 1.0)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces automated tests for the `build_distribution` function in `scripts/slots-mc.py`. Because the filename contains a hyphen, the file is dynamically loaded in the tests using `importlib.util`.

📊 **Coverage:** What scenarios are now tested
The following scenarios are now covered by the test file `scripts/test_slots_mc.py`:
- `test_build_distribution_empty()`: Ensures that an empty list properly raises a `ValueError` with the correct error message.
- `test_build_distribution_sum_too_high()`: Verifies that passing outcomes with probabilities summing to > 1.0 correctly raises a `ValueError`.
- `test_build_distribution_exact_sum()`: Validates that passing exact probabilities totaling to 1.0 creates the expected list of `Outcome` objects without adding residuals.
- `test_build_distribution_with_residual()`: Checks that passing probabilities summing < 1.0 properly appends a residual outcome named "loss (residual)" with a `0.0` multiplier and a probability equal to the missing fraction.

✨ **Result:** The improvement in test coverage
We now have reliable, robust automated unit tests ensuring the critical validation and setup paths of our slots Monte Carlo simulator are functioning flawlessly. Extraneous binaries (`__pycache__`) were ignored and excluded from this PR.

---
*PR created automatically by Jules for task [6881980891575054469](https://jules.google.com/task/6881980891575054469) started by @ealdent*