### PR TITLE
🧪 test: add coverage for ci_95 slots-mc statistic util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 *.pem
 *.key
 node_modules/
+
+# pytest
+__pycache__/
+*.pyc
+.coverage

--- a/scripts/tests/test_slots_mc.py
+++ b/scripts/tests/test_slots_mc.py
@@ -1,0 +1,50 @@
+import math
+import sys
+from pathlib import Path
+import importlib.util
+
+# Load slots-mc.py dynamically since it has a hyphen in the name
+script_path = Path(__file__).parent.parent / "slots-mc.py"
+spec = importlib.util.spec_from_file_location("slots_mc", script_path)
+slots_mc = importlib.util.module_from_spec(spec)
+sys.modules["slots_mc"] = slots_mc
+spec.loader.exec_module(slots_mc)
+
+def test_ci_95_empty():
+    """Test ci_95 with an empty list."""
+    result = slots_mc.ci_95([])
+    assert math.isnan(result[0])
+    assert math.isnan(result[1])
+
+def test_ci_95_single_element():
+    """Test ci_95 with a single element list."""
+    val = 42.0
+    result = slots_mc.ci_95([val])
+    assert result[0] == val
+    assert math.isnan(result[1])
+
+def test_ci_95_small_list():
+    """Test ci_95 with a small list (n < 30)."""
+    xs = [10.0, 20.0]
+    result = slots_mc.ci_95(xs)
+    mean = 15.0
+    half = 1.96 * (5.0 / math.sqrt(2))
+    assert math.isclose(result[0], mean - half)
+    assert math.isclose(result[1], mean + half)
+
+def test_ci_95_large_list():
+    """Test ci_95 with a large list (n >= 30)."""
+    xs = [0.0] * 15 + [10.0] * 15
+    result = slots_mc.ci_95(xs)
+    mean = 5.0
+    stdev = math.sqrt(750.0 / 29.0)
+    half = 1.96 * (stdev / math.sqrt(30))
+    assert math.isclose(result[0], mean - half)
+    assert math.isclose(result[1], mean + half)
+
+def test_ci_95_constant_list():
+    """Test ci_95 with a constant list to verify no math domain errors (div by zero etc)."""
+    xs = [10.0] * 5
+    result = slots_mc.ci_95(xs)
+    assert result[0] == 10.0
+    assert result[1] == 10.0


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `ci_95` function in `scripts/slots-mc.py`. Because the script has a hyphenated name, `importlib` was used to load the target method dynamically.

📊 **Coverage:** Covered edge cases explicitly:
- Empty lists (asserts NaN outputs)
- Single-element lists (asserts NaN standard deviation bounding)
- Small datasets (<30 items) that trigger population standard deviation (`statistics.pstdev`) logic.
- Large datasets (>=30 items) that trigger sample standard deviation (`statistics.stdev`) logic.
- Zero-variance lists (prevents divide-by-zero or related math domain errors)

✨ **Result:** Enhanced the codebase with zero-regression test coverage for the statistical utility, ensuring safe refactoring in the future. Prevented accidental checking-in of Python cached artifacts via `.gitignore` updates.

---
*PR created automatically by Jules for task [12760768684243358947](https://jules.google.com/task/12760768684243358947) started by @ealdent*