### PR TITLE
test(slots-mc): add unit tests for next_bet_martingale

### DIFF
--- a/scripts/test_slots_mc.py
+++ b/scripts/test_slots_mc.py
@@ -63,41 +63,59 @@ def test_build_distribution_with_residual():
 
 @pytest.fixture
 def reset_martingale_globals():
-    """Reset PARAMS and CONFIG to defaults so martingale tests don't leak state."""
+    """Set PARAMS/CONFIG to known values for the test, then restore prior values."""
+    saved = (
+        slots_mc.PARAMS.base_bet,
+        slots_mc.PARAMS.loss_mult,
+        slots_mc.PARAMS.treat_push_as_win,
+        slots_mc.CONFIG.max_bet,
+    )
     slots_mc.PARAMS.base_bet = 5000
     slots_mc.PARAMS.loss_mult = 2.0
     slots_mc.PARAMS.treat_push_as_win = False
     slots_mc.CONFIG.max_bet = 250000
-    yield
+    try:
+        yield
+    finally:
+        (
+            slots_mc.PARAMS.base_bet,
+            slots_mc.PARAMS.loss_mult,
+            slots_mc.PARAMS.treat_push_as_win,
+            slots_mc.CONFIG.max_bet,
+        ) = saved
 
 
 def test_martingale_zero_or_negative_last_bet_returns_base(reset_martingale_globals):
-    assert slots_mc.next_bet_martingale(1_000_000, 0, 0.0, 0, 1) == slots_mc.PARAMS.base_bet
-    assert slots_mc.next_bet_martingale(1_000_000, -5000, 0.0, 0, 1) == slots_mc.PARAMS.base_bet
+    base = slots_mc.PARAMS.base_bet
+    assert slots_mc.next_bet_martingale(1_000_000, 0, 0.0, 0, 1) == base
+    assert slots_mc.next_bet_martingale(1_000_000, -base, 0.0, 0, 1) == base
 
 
 def test_martingale_resets_to_base_after_win(reset_martingale_globals):
     # last_mult > 1.0 = win
-    assert slots_mc.next_bet_martingale(1_000_000, 20000, 2.0, 1, 0) == 5000
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 2.0, 1, 0) == slots_mc.PARAMS.base_bet
 
 
 def test_martingale_doubles_after_loss(reset_martingale_globals):
-    # last_mult = 0.0 = loss; bet should double
-    assert slots_mc.next_bet_martingale(1_000_000, 5000, 0.0, 0, 1) == 10000
-    assert slots_mc.next_bet_martingale(1_000_000, 10000, 0.0, 0, 2) == 20000
+    # last_mult = 0.0 = loss; bet should multiply by loss_mult
+    mult = slots_mc.PARAMS.loss_mult
+    assert slots_mc.next_bet_martingale(1_000_000, 5000, 0.0, 0, 1) == int(5000 * mult)
+    assert slots_mc.next_bet_martingale(1_000_000, 10000, 0.0, 0, 2) == int(10000 * mult)
 
 
 def test_martingale_caps_at_max_bet(reset_martingale_globals):
-    # 200000 * 2 = 400000 but max_bet caps at 250000
-    assert slots_mc.next_bet_martingale(1_000_000, 200000, 0.0, 0, 1) == 250000
+    # 200000 * 2 = 400000 but max_bet caps the result
+    cap = slots_mc.CONFIG.max_bet
+    assert slots_mc.next_bet_martingale(1_000_000, 200000, 0.0, 0, 1) == cap
 
 
 def test_martingale_push_as_win_resets(reset_martingale_globals):
     slots_mc.PARAMS.treat_push_as_win = True
     # last_mult = 1.0 (push), treated as win => reset
-    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 1, 0) == 5000
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 1, 0) == slots_mc.PARAMS.base_bet
 
 
 def test_martingale_push_as_loss_doubles(reset_martingale_globals):
     # treat_push_as_win defaults to False; 1.0 multiplier counts as loss for progression
-    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 0, 1) == 40000
+    mult = slots_mc.PARAMS.loss_mult
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 0, 1) == int(20000 * mult)

--- a/scripts/test_slots_mc.py
+++ b/scripts/test_slots_mc.py
@@ -59,3 +59,45 @@ def test_build_distribution_with_residual():
     assert dist[2].mult == 0.0
 
     assert math.isclose(sum(d.prob for d in dist), 1.0)
+
+
+@pytest.fixture
+def reset_martingale_globals():
+    """Reset PARAMS and CONFIG to defaults so martingale tests don't leak state."""
+    slots_mc.PARAMS.base_bet = 5000
+    slots_mc.PARAMS.loss_mult = 2.0
+    slots_mc.PARAMS.treat_push_as_win = False
+    slots_mc.CONFIG.max_bet = 250000
+    yield
+
+
+def test_martingale_zero_or_negative_last_bet_returns_base(reset_martingale_globals):
+    assert slots_mc.next_bet_martingale(1_000_000, 0, 0.0, 0, 1) == slots_mc.PARAMS.base_bet
+    assert slots_mc.next_bet_martingale(1_000_000, -5000, 0.0, 0, 1) == slots_mc.PARAMS.base_bet
+
+
+def test_martingale_resets_to_base_after_win(reset_martingale_globals):
+    # last_mult > 1.0 = win
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 2.0, 1, 0) == 5000
+
+
+def test_martingale_doubles_after_loss(reset_martingale_globals):
+    # last_mult = 0.0 = loss; bet should double
+    assert slots_mc.next_bet_martingale(1_000_000, 5000, 0.0, 0, 1) == 10000
+    assert slots_mc.next_bet_martingale(1_000_000, 10000, 0.0, 0, 2) == 20000
+
+
+def test_martingale_caps_at_max_bet(reset_martingale_globals):
+    # 200000 * 2 = 400000 but max_bet caps at 250000
+    assert slots_mc.next_bet_martingale(1_000_000, 200000, 0.0, 0, 1) == 250000
+
+
+def test_martingale_push_as_win_resets(reset_martingale_globals):
+    slots_mc.PARAMS.treat_push_as_win = True
+    # last_mult = 1.0 (push), treated as win => reset
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 1, 0) == 5000
+
+
+def test_martingale_push_as_loss_doubles(reset_martingale_globals):
+    # treat_push_as_win defaults to False; 1.0 multiplier counts as loss for progression
+    assert slots_mc.next_bet_martingale(1_000_000, 20000, 1.0, 0, 1) == 40000


### PR DESCRIPTION
## Summary

Adds 6 unit tests for `next_bet_martingale` in `scripts/slots-mc.py`, filling the gap left after #17 (`build_distribution`), #19 (`theoretical_ev`), and #22 (`ci_95`) covered the other pure functions but not the strategy logic itself.

Tests cover:
- Zero/negative `last_bet` returns base
- Win resets to base
- Loss doubles the bet
- Doubled bet caps at `CONFIG.max_bet`
- Push counts as win when `treat_push_as_win` is `True`
- Push counts as loss when `treat_push_as_win` is `False` (default)

## Why this is separate from #18

This is the salvageable kernel of #18. That PR drifted out of scope during repeated merge-conflict rounds and now duplicates work already merged via #14, #15, #16, #17, #19, #20, #21, #22, #23, #24, and #26 — plus it triplicates the slots-mc test files across three directories. Closing #18 in favor of this focused replacement.

## Test plan

- [x] `pytest scripts/test_slots_mc.py -v` — all 10 tests pass (4 existing + 6 new)
- [x] Existing test files in `scripts/tests/` and `tests/` still pass in isolation

---
_Generated by [Claude Code](https://claude.ai/code/session_013EizMEcMDASVGkvLL3ZNh3)_