### PR TITLE
🧪 Add tests for build_distribution error paths

### DIFF
--- a/tests/test_slots_mc.py
+++ b/tests/test_slots_mc.py
@@ -10,7 +10,21 @@ slots_mc = importlib.util.module_from_spec(spec)
 sys.modules["slots_mc"] = slots_mc
 spec.loader.exec_module(slots_mc)
 
-from slots_mc import theoretical_ev, Outcome
+from slots_mc import theoretical_ev, Outcome, build_distribution
+
+def test_build_distribution_empty_outcomes():
+    """Test build_distribution raises ValueError on empty list."""
+    with pytest.raises(ValueError, match="Please paste your previously determined probabilities into OUTCOMES."):
+        build_distribution([])
+
+def test_build_distribution_sum_too_high():
+    """Test build_distribution raises ValueError when sum of probabilities > 1."""
+    outcomes = [
+        ("outcome1", 0.6, 1.0),
+        ("outcome2", 0.5, 2.0),
+    ]
+    with pytest.raises(ValueError, match=r"Outcome probabilities sum to 1\.100000 \(>1\)\. Fix your inputs\."):
+        build_distribution(outcomes)
 
 def test_theoretical_ev_empty():
     """Test with an empty list of outcomes."""


### PR DESCRIPTION
🎯 **What:** Missing tests for `build_distribution` error paths in `scripts/slots-mc.py`.
📊 **Coverage:** The scenarios where an empty `outcomes_cfg` list is provided or where probabilities sum to > 1.0 are now tested. Both correctly raise a `ValueError` with clear guidance to fix inputs.
✨ **Result:** Test coverage for `build_distribution` value errors has improved, preventing regressions when parsing inputs for Monte Carlo outcomes.

---
*PR created automatically by Jules for task [15351366324984315038](https://jules.google.com/task/15351366324984315038) started by @ealdent*