### PR TITLE
Fix mobile layout for twilight rows in infographic

### DIFF
--- a/utils/sky_weather_infographic.html
+++ b/utils/sky_weather_infographic.html
@@ -226,10 +226,11 @@
       .row {
         padding: 10px;
         gap: 8px;
+        flex-wrap: wrap;
       }
       .left {
         gap: 8px;
-        flex: 1;
+        flex: 1 1 100%;
         min-width: 0;
       }
       .ico {
@@ -256,6 +257,7 @@
         font-size: 11px;
         flex-shrink: 0;
         text-align: right;
+        width: 100%;
       }
 
       /* Content padding */


### PR DESCRIPTION
This commit fixes an issue where the twilight rows in `utils/sky_weather_infographic.html` were squashed horizontally on mobile devices due to lack of flex wrapping. Flex-wrap was added, and the child elements were set to 100% width on smaller viewports, ensuring content stacks properly and remains readable without overlapping or clipping.

---
*PR created automatically by Jules for task [10569027761698504886](https://jules.google.com/task/10569027761698504886) started by @ealdent*